### PR TITLE
Handle exceptions in python 3.*

### DIFF
--- a/captionstransformer/core.py
+++ b/captionstransformer/core.py
@@ -10,7 +10,11 @@ class Reader(object):
     def read(self):
         self.rawcontent = self.fileobject.read()
         if type(self.rawcontent) == str:
-            self.rawcontent = self.rawcontent.decode(self.encoding)
+            try:
+                self.rawcontent = self.rawcontent.decode(self.encoding)
+            except AttributeError:
+                pass
+
         self.text_to_captions()
         return self.captions
 
@@ -130,7 +134,11 @@ class Caption(object):
 
     def set_text(self, value):
         if type(value) == str:
-            value = str.decode(self.encoding)
+            try:
+                value = str.decode(self.encoding)
+            except AttributeError:
+                pass
+
         elif type(value) != unicode:
             raise ValueError("text must be either encoded string or unicode")
         self._text = value


### PR DESCRIPTION
I'm using this library in my project and I've just moved to Python 3.5.
Everything works good so far except `decode()` method because every string in Python 3.\* is already in unicode. I made small workaround to prevent problems with Python 3.*

Thank you for you library!
